### PR TITLE
Return latest rechunk run by default

### DIFF
--- a/ncviewjs_backend/dataset_processing.py
+++ b/ncviewjs_backend/dataset_processing.py
@@ -88,6 +88,9 @@ def process_dataset(*, dataset: Dataset, rechunk_run: RechunkRun, session: Sessi
 
 
 def validate_and_rechunk(*, dataset: Dataset, session: Session, rechunk_run: RechunkRun):
+    """Validate the store and rechunk the dataset"""
+    rechunk_run.status = 'in_progress'
+    _update_entry_in_db(session=session, item=rechunk_run)
     validate_zarr_store(dataset.url)
 
     # Update the dataset in the database with the CF axes

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,7 +7,6 @@ urls = [
     "s3://carbonplan-data-viewer/demo/AGDC_100MB.zarr",
 ]
 
-
 columns = {"id", "url", "bucket", "key", "protocol", "md5_id", "cf_axes", "last_accessed", "size"}
 
 
@@ -29,7 +28,8 @@ def test_put_store(test_app_with_db, url, force):
     "url",
     urls,
 )
-def test_get_dataset(test_app_with_db, url):
+@pytest.mark.parametrize("latest", [True, False])
+def test_get_dataset(test_app_with_db, url, latest):
 
     response = test_app_with_db.put(
         '/datasets/',
@@ -37,7 +37,7 @@ def test_get_dataset(test_app_with_db, url):
     )
 
     data = response.json()
-    response = test_app_with_db.get(f"/datasets/{data['id']}")
+    response = test_app_with_db.get(f"/datasets/{data['id']}?latest={latest}")
     assert response.status_code == 200
     data = response.json()
     assert columns.issubset(set(data.keys()))


### PR DESCRIPTION
`/datasets/{id}` endpoint returns a dataset w/ the associated rechunk runs. This PR modifies this behavior by introducing a query parameter `latest` which is set to True by default. w/ this change `/datasets/{id}` returns a dataset plus the latest rechunk run.   Setting this parameter to `False` : `/datasets/{id}?latest=False` returns all the rechunk runs. 