### PR TITLE
Update error reporting and increase dataset size limit

### DIFF
--- a/ncviewjs_backend/dataset_processing.py
+++ b/ncviewjs_backend/dataset_processing.py
@@ -91,13 +91,13 @@ def validate_and_rechunk(*, dataset: Dataset, session: Session, rechunk_run: Rec
     """Validate the store and rechunk the dataset"""
     rechunk_run.status = 'in_progress'
     _update_entry_in_db(session=session, item=rechunk_run)
-    validate_zarr_store(dataset.url)
 
     # Update the dataset in the database with the CF axes
     ds_info = get_dataset_info(dataset.url)
     dataset.cf_axes = ds_info['cf_axes']
     dataset.size = ds_info['size']
     _update_entry_in_db(session=session, item=dataset)
+    validate_zarr_store(dataset.url)
     logger.info(f'Validation of store: {dataset.url} succeeded')
 
     # Rechunk the dataset

--- a/ncviewjs_backend/dataset_processing.py
+++ b/ncviewjs_backend/dataset_processing.py
@@ -8,7 +8,7 @@ from .logging import get_logger
 from .models.dataset import Dataset, RechunkRun
 from .rechunking.rechunk import rechunk_flow
 
-DATASET_SIZE_THRESHOLD = 7e9
+DATASET_SIZE_THRESHOLD = 60e9
 
 logger = get_logger()
 
@@ -81,7 +81,8 @@ def process_dataset(*, dataset: Dataset, rechunk_run: RechunkRun, session: Sessi
         # update the rechunk run in the database
         rechunk_run.status = "completed"
         rechunk_run.outcome = "failure"
-        rechunk_run.error_message = traceback.format_exc()
+        trace = traceback.format_exc()
+        rechunk_run.error_message = trace.splitlines()[-1]
         _update_entry_in_db(session=session, item=rechunk_run)
         logger.error(f'Rechunking run: {rechunk_run}\nfailed with error: {exc}')
         raise RuntimeError('Dataset processing failed.') from exc


### PR DESCRIPTION
This PR

- adds a `error_message_traceback` entry to the rechunk run entry

- simplifies the existing `error_message` by making it human readable

- increases the dataset size limit to `60GB`